### PR TITLE
Include `{{varname}}` in serial print

### DIFF
--- a/components/Coders/PushButton.json
+++ b/components/Coders/PushButton.json
@@ -17,7 +17,7 @@
   ],
   "code": {
     "setup": "{{varname}}.init();\n",
-    "snippetCode": "//Read pushbutton state. \n//if button is pressed function will return HIGH (1). if not function will return LOW (0). \n//for debounce funtionality try also {{varname}}.onPress(), .onRelease() and .onChange().\n//if debounce is not working properly try changing 'debounceDelay' variable in Button.h\nbool {{varname}}Val = {{varname}}.read();\nSerial.print(F(\"Val: \")); Serial.println({{varname}}Val);\n",
+    "snippetCode": "//Read pushbutton state. \n//if button is pressed function will return HIGH (1). if not function will return LOW (0). \n//for debounce funtionality try also {{varname}}.onPress(), .onRelease() and .onChange().\n//if debounce is not working properly try changing 'debounceDelay' variable in Button.h\nbool {{varname}}Val = {{varname}}.read();\nSerial.print(F(\"{{varname}}Val: \")); Serial.println({{varname}}Val);\n",
     "constructors": "{{classname}} {{varname}}({{2}});"
   },
   "license": "circuito",


### PR DESCRIPTION
By including `{{varname}}` in the serial print, the user will know which button is which when there is more then one button in the circuit.